### PR TITLE
added_xiaomi_buds_5_modes_support

### DIFF
--- a/DeviceFollower.qml
+++ b/DeviceFollower.qml
@@ -101,26 +101,30 @@ Item {
   readonly property string modelId: String(reading.modelId || "")
   readonly property string bleAddress: String(reading.bleAddress || "")
 
-  // ---- Listening mode. Two devices, two protocols, one piece of state: the
+  // ---- Listening mode. Three devices, three protocols, one piece of state: the
   //      panel shows a mode and writes a mode, and which helper carries it is
   //      decided per device from the UUIDs in its SDP record.
   //
-  //        sony-bridge  Sony's MDR protocol v2, over an RFCOMM channel the
-  //                     headset itself serves. Deterministic: a device that
-  //                     advertises the UUID speaks the protocol, so this path
-  //                     needs no Fast Pair, no rotating address and no cache of
-  //                     which models answered.
-  //        jbl-bridge   JBL's BLE GATT service, on the earbuds' BLE side at an
-  //                     address that rotates and is announced only on the
-  //                     Message Stream — so that path needs the reader, and is
-  //                     unreachable without it.
+  //        sony-bridge    Sony's MDR protocol v2, over an RFCOMM channel the
+  //                       headset itself serves. Deterministic: a device that
+  //                       advertises the UUID speaks the protocol, so this path
+  //                       needs no Fast Pair, no rotating address and no cache of
+  //                       which models answered.
+  //        xiaomi-bridge  Compact GAIA on standard SPP. The CSR GAIA UUID in
+  //                       the SDP record is the claim; the socket is SPP. Same
+  //                       lifecycle as Sony: Classic address, no Fast Pair.
+  //        jbl-bridge     JBL's BLE GATT service, on the earbuds' BLE side at an
+  //                       address that rotates and is announced only on the
+  //                       Message Stream - so that path needs the reader, and is
+  //                       unreachable without it.
   //
   //      Either way exactly one process owns the link, because writes and the
   //      device's own notifications (a mode changed by touching the earbud) must
   //      share one connection; this follower talks to it through its stdin, and
-  //      both bridges report on the same contract into the same state.
+  //      the bridges report on the same contract into the same state.
   readonly property string jblBridgePath: Qt.resolvedUrl("jbl-bridge").toString().replace(/^file:\/\//, "")
   readonly property string sonyBridgePath: Qt.resolvedUrl("sony-bridge").toString().replace(/^file:\/\//, "")
+  readonly property string xiaomiBridgePath: Qt.resolvedUrl("xiaomi-bridge").toString().replace(/^file:\/\//, "")
   property var ancState: ({})
   property bool ancEnabled: true
   readonly property bool jblWanted: useModeControl && useFastPair && ancEnabled && connected
@@ -138,6 +142,7 @@ Item {
   property string ancRunError: ""
   property string ancErrorRaw: ""
   property bool sonyEnabled: true
+  property bool xiaomiEnabled: true
 
   // What this device serves, read once per connection with `bluetoothctl info`.
   // Empty while it is not connected, or while the probe is still out.
@@ -163,7 +168,7 @@ Item {
 
   // Whichever bridge this device calls for. They are exclusive — the backend is
   // one string — so this is "the bridge", not "either of two links".
-  readonly property bool bridgeRunning: ancBridge.running || sonyBridge.running
+  readonly property bool bridgeRunning: ancBridge.running || sonyBridge.running || xiaomiBridge.running
   // The bridge is up and the device has answered on it, which is the only state
   // in which a write has somewhere to land.
   readonly property bool ancLive: bridgeRunning && ancAnswered
@@ -171,9 +176,10 @@ Item {
   // switched off, because that needs no explaining.
   readonly property string ancError: {
     if (!useModeControl) return ""
-    // Only the JBL path goes through the Message Stream. A Sony headset serves
-    // its own channel and does not care whether Fast Pair is on.
-    if (controlBackend !== "sony" && !useFastPair) return "needs Fast Pair for the BLE address"
+    // Only the JBL path goes through the Message Stream. Sony and Xiaomi serve
+    // their own Classic channels and do not care whether Fast Pair is on.
+    if (controlBackend !== "sony" && controlBackend !== "xiaomi" && !useFastPair)
+      return "needs Fast Pair for the BLE address"
     return ancErrorRaw
   }
 
@@ -182,11 +188,13 @@ Item {
   // session, and how long to wait before asking again.
   readonly property int modeSupportKnown: Model.supportVerdict(service ? service.modeSupport : ({}), modelId)
   readonly property bool ancModelParked: service ? service.ancParked[modelId] === true : false
-  readonly property bool sonyAddressParked: service ? service.sonyParked[address] === true : false
+  readonly property bool addressParked: service ? service.sonyParked[address] === true : false
+  readonly property bool sonyAddressParked: addressParked
   // How long to wait before the next attempt, keyed by whatever identifies the
-  // device for the backend in play — the Fast Pair model for the JBL bridge, the
-  // Classic address for the Sony one.
-  readonly property string ancBackoffKey: controlBackend === "sony" ? address : modelId
+  // device for the backend in play - the Fast Pair model for the JBL bridge, the
+  // Classic address for Sony and Xiaomi.
+  readonly property string ancBackoffKey: (controlBackend === "sony" || controlBackend === "xiaomi")
+    ? address : modelId
 
   readonly property int bluezLevel: Model.batteryLevel(device)
   // The bar carries one number: the headset's own figure where there is only
@@ -335,6 +343,7 @@ Item {
     }
     if (ancRestart.running) { ancRestart.stop(); ancEnabled = true }
     if (sonyRestart.running) { sonyRestart.stop(); sonyEnabled = true }
+    if (xiaomiRestart.running) { xiaomiRestart.stop(); xiaomiEnabled = true }
     if (!useFastPair || !service) return
     // The service cycles this device's channel and leaves every other device's
     // alone; it says whether the request went out at all, because a reader that
@@ -365,6 +374,7 @@ Item {
     if (!ancSupported || !ancLive) return false
     if (modesAvailable.indexOf(String(mode)) === -1) return false
     if (sonyBridge.running) sonyBridge.write("set " + mode + "\n")
+    else if (xiaomiBridge.running) xiaomiBridge.write("set " + mode + "\n")
     else ancBridge.write("set " + mode + "\n")
     return true
   }
@@ -658,6 +668,56 @@ Item {
     onTriggered: follower.sonyEnabled = true
   }
 
+  // Lives only while Xiaomi / QCC buds that advertise CSR GAIA are connected.
+  // Same gates as Sony: the channel is Classic SPP, so there is no BLE address
+  // to wait for and no Fast Pair to depend on. An address that already failed
+  // for good this session is parked on the same map Sony uses.
+  Process {
+    id: xiaomiBridge
+    running: follower.useModeControl && follower.xiaomiEnabled && follower.connected
+      && follower.controlBackend === "xiaomi"
+      && !follower.addressParked
+    command: [follower.xiaomiBridgePath, follower.address]
+    stdinEnabled: true
+    stdout: SplitParser {
+      onRead: function(line) { follower.applyAncLine(line) }
+    }
+    stderr: StdioCollector { id: xiaomiStderr; waitForEnd: true }
+    onRunningChanged: {
+      if (running) {
+        follower.ancRunError = ""
+        follower.ancErrorRaw = ""
+      }
+      follower.ancState = ({})
+      follower.ancAnswered = false
+    }
+    onExited: function(exitCode, exitStatus) {
+      if (exitCode === 3 && follower.service)
+        follower.service.parkAddress(follower.address)
+      if (exitCode === 3) {
+        follower.ancRunError = ""
+        follower.ancErrorRaw = ""
+      } else if (exitCode !== 0 && follower.ancRunError === "") {
+        follower.ancErrorRaw = Model.shortError(xiaomiStderr.text, exitCode === 4
+          ? "the listening-mode bridge could not start"
+          : "the listening-mode link dropped (exit " + exitCode + ")")
+      }
+
+      follower.xiaomiEnabled = false
+      xiaomiRestart.interval = follower.service
+        ? follower.service.ancBackoffFor(follower.address) : 10000
+      if ((exitCode === 1 || exitCode === 4) && follower.service)
+        follower.service.bumpAncBackoff(follower.address)
+      xiaomiRestart.restart()
+    }
+  }
+
+  Timer {
+    id: xiaomiRestart
+    repeat: false
+    onTriggered: follower.xiaomiEnabled = true
+  }
+
   // Reads the device's SDP UUIDs, which is how the backend is chosen. Started by
   // probeUuids() rather than by a `running` binding: this process exits as soon
   // as it has printed, and a binding that is still true at that moment is an
@@ -667,7 +727,7 @@ Item {
     stdout: StdioCollector { id: uuidProbeOut; waitForEnd: true }
     onExited: function(exitCode, exitStatus) {
       // A probe that failed says nothing about the device, and an empty list is
-      // exactly that: no Sony UUID seen, so a Fast Pair BLE address decides.
+      // exactly that: no Sony or GAIA UUID seen, so a Fast Pair BLE address decides.
       follower.deviceUuids = exitCode === 0
         ? Model.uuidsFromBluetoothctl(uuidProbeOut.text)
         : []

--- a/Model.js
+++ b/Model.js
@@ -424,13 +424,16 @@ function readerLevel(state, key) {
 
 // ---- Which helper can control the listening mode of a given device.
 //
-// Two protocols, decided per device from its SDP record rather than from its
+// Three protocols, decided per device from its SDP record rather than from its
 // name: Sony's MDR v2 lives on an RFCOMM channel the headset itself serves, and
-// advertising the UUID is the whole claim — a device that lists it speaks it.
+// advertising the UUID is the whole claim - a device that lists it speaks it.
+// Xiaomi Buds 5 Pro (and other QCC sets that advertise CSR GAIA) speak Compact
+// GAIA on standard SPP; the GAIA UUID is the claim, SPP is the socket.
 // JBL's is a BLE GATT service at an address that rotates and is announced only
 // on the Fast Pair Message Stream, so knowing that address is what makes that
 // path possible at all.
 var SONY_MDR_V2_UUID = "956c7b26-d49a-4ba8-b03f-b17d393cb6e2"
+var CSR_GAIA_UUID = "00001100-d102-11e1-9b23-00025b00a5a5"
 
 // The UUIDs `bluetoothctl info <address>` printed, lowercased.
 // Quickshell.Bluetooth exposes no uuids property, so the SDP record is read the
@@ -450,19 +453,24 @@ function uuidsFromBluetoothctl(text) {
   return out
 }
 
-// "sony", "jbl" or "" — the backend to run for this device, and the empty string
-// for a device neither path can reach. The Sony UUID wins because it is the
-// stronger statement: it comes from the device's own SDP record, while a known
-// BLE address only says the Message Stream is up, which every Fast Pair device
-// does whether or not it answers a mode query.
+// "sony", "xiaomi", "jbl" or "" - the backend to run for this device, and the
+// empty string for a device no path can reach. SDP UUIDs win because they come
+// from the device's own record: Sony first, then CSR GAIA (Xiaomi / QCC on
+// SPP). A known BLE address only says the Message Stream is up, which every
+// Fast Pair device does whether or not it answers a mode query, so it is last.
 function controlBackend(uuids, bleAddress) {
   var list = uuids || []
-  for (var i = 0; i < list.length; i++)
-    if (str(list[i]).trim().toLowerCase() === SONY_MDR_V2_UUID) return "sony"
+  var gaia = false
+  for (var i = 0; i < list.length; i++) {
+    var id = str(list[i]).trim().toLowerCase()
+    if (id === SONY_MDR_V2_UUID) return "sony"
+    if (id === CSR_GAIA_UUID) gaia = true
+  }
+  if (gaia) return "xiaomi"
   return str(bleAddress).trim() !== "" ? "jbl" : ""
 }
 
-// The order the panel draws them in, and the only names either bridge may use.
+// The order the panel draws them in, and the only names a bridge may use.
 var MODE_ORDER = ["off", "anc", "ambient", "talkthru"]
 
 // Which modes to offer for the state the bridge last reported. A line with no

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -6,10 +6,11 @@ Its *audio* side is BR/EDR only — every profile `bluetoothctl info` lists is
 RFCOMM or A2DP, and there is no GATT to read on it. The control protocol is on a
 separate LE connection: [further down](#the-control-protocol-lives-on-ble-and-it-is-fully-working).
 
-The [last section](#sony-mdr-v2--the-listening-mode-on-the-wh-ch720n) is a
+The [Sony section](#sony-mdr-v2--the-listening-mode-on-the-wh-ch720n) is a
 different device and a different protocol: a **Sony WH-CH720N**
 (`B0:11:22:33:44:55`), whose listening mode is on an RFCOMM channel of its own.
-Everything before it is the JBL.
+The [last section](#xiaomi-buds-5-pro---compact-gaia-on-spp) is Xiaomi Buds 5
+Pro: Compact GAIA on standard SPP. Everything before Sony is the JBL.
 
 The tools that produced all of this are in [`tools/`](tools/). The four Python
 probes each register an `org.bluez.Profile1` for one UUID, so BlueZ does the SDP
@@ -18,9 +19,10 @@ left registered after the process exits. [`tools/jbl-anc`](tools/jbl-anc) is the
 odd one out: it drives `btgatt-client` over LE, and shells out to
 `tools/gfps_probe.py` only to read the rotating BLE address, and only when there
 is no widget running to be asked for it.
-[`tools/sony_probe.py`](tools/sony_probe.py) is the newest, and the only probe
-that speaks a framed protocol rather than dumping bytes: it does the Sony
-handshake and asks each candidate NC/ASM variant in turn.
+[`tools/sony_probe.py`](tools/sony_probe.py) and
+[`tools/xiaomi_probe.py`](tools/xiaomi_probe.py) speak framed protocols rather
+than dumping bytes: Sony does the MDR handshake and asks each NC/ASM variant;
+Xiaomi does Compact GAIA on SPP.
 
 ## The channels
 
@@ -637,3 +639,103 @@ stale-readback and stored-level behaviours above were pinned down.
 The widget's own bridge holds the same profile, so turn `useModeControl` off
 before running the probe, or BlueZ will refuse the registration to whichever
 asks second.
+
+## Xiaomi Buds 5 Pro - Compact GAIA on SPP
+
+A third device and a third protocol, confirmed on **Xiaomi Buds 5 Pro**
+(`64:8F:DB:87:06:CB`, Qualcomm QCC-7228). There is no Google Fast Pair UUID, so
+per-earbud battery over the Message Stream is not available. BlueZ's HFP figure
+is the one the widget already shows. Two GATT Battery Service instances
+(`0000180f` / `00002a19`) exist on the device object, but ATT reads fail with
+*Not connected* while Classic A2DP is up; the GET on this channel that Moondrop
+uses for left/right percent (`0x1A01`) answered `01 00` / `02 00` / `03 ff`
+against a live BlueZ reading of ~90%, so those bytes are not a usable
+percentage. Listening mode is what this section is about.
+
+`bluetoothctl info` lists, among others:
+
+| UUID | What it is | Answers? |
+|---|---|---|
+| `00001100-d102-11e1-9b23-00025b00a5a5` | CSR GAIA | advertised; `ConnectProfile` returns *not supported* |
+| `00001101-0000-1000-8000-00805f9b34fb` | standard SPP | **Yes - handshake, GET/SET listening mode** |
+| `00000837-d103-0004-bf7f-2942153d354b` | vendor SPP (vivo uses this) | connects, no replies |
+| `2587db3c-ce70-4fc9-935f-777ab4188fd7` | vendor | *not supported* |
+| `df21fe2c-2515-4fdb-8886-f12c4d67927c` | Fast Pair Message Stream | **absent** |
+
+The widget picks this backend from the CSR GAIA UUID in the SDP record, then
+opens **SPP**. Same Profile1 arrangement as Sony: `Role` `client`, `Channel` `0`,
+async `ConnectProfile`, retry on `br-connection-busy`. `AutoConnect` must stay
+false: with it on, BlueZ handed a second socket and the probe replayed its plan
+on top of itself.
+
+Do not send Xiaomi `FE DC BA …` frames on this socket: they closed it. Do not
+send GAIA v1 factory-reset / power-off (`0x0104`, `0x0202`, `0x0204`).
+
+### Frames
+
+Compact GAIA, the same wrapping Moondrop and vivo use:
+
+```
+FF <ver> <flags=00> <payloadLen> <vendor u16be> <cmd u16be> <payload>
+```
+
+This device replies with **version 3**. Flags stayed 0 (no checksum, no
+extended length). Several frames can arrive in one `read()`.
+
+Handshake, vendor `0x000A` (generic GAIA):
+
+```
+->  ff 03 00 00  000a 0300
+<-  ff 03 00 04  000a 8300  00030301
+```
+
+Device commands use vendor `0x001D` (QTIL GAIA v3 / the same vendor Moondrop
+uses). GET response = GET + `0x0100`. Error = that value with `0x0080` set,
+payload a GAIA status (`05` invalid parameter, `01` not supported).
+
+### Listening mode
+
+| sent | reply | meaning |
+|---|---|---|
+| `0x1003` empty | `0x1103` 5 bytes | GET |
+| `0x1004` 1 byte | `0x1104` empty | SET ack |
+| `0x1004` 5 bytes (a copy of GET) | `0x1184` payload `05` | rejected |
+
+GET payloads actually seen, first byte echoing the SET byte:
+
+| SET | GET payload | panel name |
+|---|---|---|
+| `00` | `00 01 00 00 00` | Off (confirmed: panel Off) |
+| `01` | `01 01 01 00 00` | ANC (confirmed: panel ANC; byte 2 is 1 only here) |
+| `02` | `02 01 00 01 00` | Ambient / transparency (same extra flags as 0x03/0x04; SET did not drop the link) |
+| `03` | `03 01 00 01 00` | accepted, not offered |
+| `04` | `04 01 00 01 00` | **reboots the buds** - Moondrop's transparency byte on this vendor; never send |
+
+Off and ANC were confirmed by using the panel. Ambient was first mapped to
+`0x04` because that is Moondrop's SET value; the buds reboot when it is sent,
+so Ambient is `0x02` instead. `0x03` is still unnamed. Nothing unsolicited
+arrived when the GET was left alone; the bridge polls GET every 2.5 s so a
+press on the bud still updates the panel.
+
+### In the widget
+
+[`xiaomi-bridge`](xiaomi-bridge) is the sibling of [`sony-bridge`](sony-bridge):
+same JSON line, same stdin `set <mode>`, same four exit codes, Classic address,
+address parked for the session on exit 3. No `level` / `voice` keys - this
+protocol has no ambient dial.
+
+```json
+{"modes": true, "mode": "anc", "available": ["off","anc","ambient"]}
+```
+
+### The probe
+
+[`tools/xiaomi_probe.py`](tools/xiaomi_probe.py):
+
+```bash
+tools/xiaomi_probe.py 64:8F:DB:87:06:CB
+tools/xiaomi_probe.py 64:8F:DB:87:06:CB 15 set:ambient
+```
+
+Turn `useModeControl` off first: SPP is one holder, like Sony's UUID.
+

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 - **The bar icon is the meter** — earbuds are drawn as a pair, a headset as
   headphones, filling up as they charge. Readable from the bar without opening
   anything.
-- **Noise control** — Off / ANC / Ambient / TalkThru, from the panel or a key.
-  JBL and Sony today; built to learn your brand.
+- **Noise control** - Off / ANC / Ambient / TalkThru, from the panel or a key.
+  JBL, Sony and Xiaomi Buds 5 Pro today; built to learn your brand.
 - **Several headphones at once** — one icon per connected set, each with its own
   panel.
 - **Low-battery notification** that names the earbud.
@@ -53,17 +53,19 @@ again — along with its settings, so note them first if you changed any.
 |:----------------------------|:----------------------------------------------------------------------|:------------------------------------------------------------------------------------------------|:-------------------------------|
 | JBL TUNE230NC TWS (earbuds) | <img src="docs/icons/yes.svg" width="14" alt="yes"> left, right, case | <img src="docs/icons/yes.svg" width="14" alt="yes"> Off · ANC · Ambient · TalkThru              | [@ncr](https://github.com/ncr) |
 | Sony WH-CH720N (over-ear)   | <img src="docs/icons/yes.svg" width="14" alt="yes"> one figure        | <img src="docs/icons/yes.svg" width="14" alt="yes"> Off · ANC · Ambient (level, Focus on Voice) | [@ncr](https://github.com/ncr) |
+| Xiaomi Buds 5 Pro (earbuds) | <img src="docs/icons/yes.svg" width="14" alt="yes"> one figure        | <img src="docs/icons/yes.svg" width="14" alt="yes"> Off · ANC · Ambient                          | —                              |
 | other Fast Pair headphones  | <img src="docs/icons/yes.svg" width="14" alt="yes"> expected          | <img src="docs/icons/unknown.svg" width="14" alt="untested">                                    | —                              |
 
 Battery works on anything that serves the Google Fast Pair Message Stream
 (`bluetoothctl info <address>` lists `df21fe2c-…`) — most headphones do — and
 falls back to BlueZ's single figure otherwise. Noise control needs the
-vendor's own channel: Sony MDR v2 (`956c7b26-…`) and JBL are spoken today.
+vendor's own channel: Sony MDR v2 (`956c7b26-…`), Compact GAIA on SPP for
+Xiaomi Buds 5 Pro (`00001100-d102-…` in the SDP record), and JBL over BLE.
 
 ## Add your own headphones
 
 Paste the text below into your AI coding agent (Claude Code, Codex, OpenCode…).
-It adds support for your headphones and opens a pull request here. How the two
+It adds support for your headphones and opens a pull request here. How the
 existing protocols were found is written down in [PROTOCOL.md](PROTOCOL.md).
 
 ```text

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.1",
   "author": "Jacek Becela",
   "license": "MIT",
-  "description": "Battery and noise control for wireless headphones in the bar. Earbuds show left, right and case levels; ANC / Ambient switching works on JBL and Sony. One icon per connected set.",
+  "description": "Battery and noise control for wireless headphones in the bar. Earbuds show left, right and case levels; ANC / Ambient switching works on JBL, Sony and Xiaomi. One icon per connected set.",
   "kinds": [
     "service",
     "bar-widget"
@@ -17,7 +17,7 @@
   },
   "barWidget": {
     "displayName": "Omaphones",
-    "description": "Battery and noise control for wireless headphones in the bar. Earbuds show left, right and case levels; ANC / Ambient switching works on JBL and Sony. One icon per connected set.",
+    "description": "Battery and noise control for wireless headphones in the bar. Earbuds show left, right and case levels; ANC / Ambient switching works on JBL, Sony and Xiaomi. One icon per connected set.",
     "category": "Audio",
     "aliases": [
       "headphones",
@@ -59,7 +59,7 @@
         "type": "boolean",
         "label": "Noise control (ANC / Ambient)",
         "defaultValue": true,
-        "description": "The MODE row: Off / ANC / Ambient, following changes made on the device too. Works on Sony MDR v2 headsets and some JBL earbuds (JBL needs Fast Pair above). Hidden when the device answers for neither."
+        "description": "The MODE row: Off / ANC / Ambient, following changes made on the device too. Works on Sony MDR v2 headsets, Xiaomi Buds 5 Pro, and some JBL earbuds (JBL needs Fast Pair above). Hidden when the device answers for neither."
       },
       {
         "key": "lowBatteryThreshold",

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -212,9 +212,12 @@ Deno.test("findByWhich answers for the device an IPC caller named", () => {
   const followed = [
     { name: "JBL TUNE230NC TWS", address: "AA:BB:CC:DD:EE:FF" },
     { name: "WH-CH720N", address: "B0:11:22:33:44:55", controlBackend: "sony" },
+    { name: "Xiaomi Buds 5 Pro", address: "64:8F:DB:87:06:CB", controlBackend: "xiaomi" },
   ];
   // The brand is often only in the backend: a Sony calls itself "WH-CH720N".
   assertEquals(Model.findByWhich(followed, "sony"), 1);
+  assertEquals(Model.findByWhich(followed, "xiaomi"), 2);
+  assertEquals(Model.findByWhich(followed, "buds 5"), 2);
   // Nothing named is the first device, which is what a no-argument call means.
   assertEquals(Model.findByWhich(followed, ""), 0);
   assertEquals(Model.findByWhich(followed, "  "), 0);
@@ -585,7 +588,21 @@ Deno.test("controlBackend picks the protocol the device advertises", () => {
   assertEquals(Model.controlBackend(sony, "48:B4:41:00:00:01"), "sony");
   // bluetoothctl prints them lowercase, but nothing guarantees it.
   assertEquals(Model.controlBackend([Model.SONY_MDR_V2_UUID.toUpperCase()], ""), "sony");
-  // No Sony UUID: the BLE address from the Message Stream is what is left.
+  // CSR GAIA in the SDP record is Xiaomi / QCC on SPP, and beats a BLE address
+  // the same way Sony does: the UUID is the device's own claim.
+  const xiaomi = [
+    "00001101-0000-1000-8000-00805f9b34fb",
+    Model.CSR_GAIA_UUID,
+  ];
+  assertEquals(Model.controlBackend(xiaomi, ""), "xiaomi");
+  assertEquals(Model.controlBackend(xiaomi, "48:B4:41:00:00:01"), "xiaomi");
+  assertEquals(Model.controlBackend([Model.CSR_GAIA_UUID.toUpperCase()], ""), "xiaomi");
+  // Sony still wins when both vendor UUIDs are listed.
+  assertEquals(
+    Model.controlBackend([Model.CSR_GAIA_UUID, Model.SONY_MDR_V2_UUID], ""),
+    "sony",
+  );
+  // No Sony or GAIA UUID: the BLE address from the Message Stream is what is left.
   assertEquals(Model.controlBackend([], "48:B4:41:00:00:01"), "jbl");
   assertEquals(Model.controlBackend(null, "48:B4:41:00:00:01"), "jbl");
   // Nothing to reach the device with.

--- a/tools/xiaomi_probe.py
+++ b/tools/xiaomi_probe.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Probe Compact GAIA on Xiaomi Buds 5 Pro: handshake, GET mode, optional SET.
+
+Usage: xiaomi_probe.py <address> [seconds] [set:off|anc|ambient]
+
+Registers an org.bluez.Profile1 for standard SPP, lets BlueZ connect it, sends
+the GAIA handshake (vendor 0x000A cmd 0x0300), then GET 0x001D/0x1003. Optional
+`set:` writes one 1-byte SET 0x1004 afterwards. Prints every frame.
+
+The widget's xiaomi-bridge holds the same SPP profile, so turn useModeControl
+off before running this, or BlueZ will refuse the registration.
+"""
+import os
+import struct
+import sys
+import time
+
+import dbus
+import dbus.mainloop.glib
+import dbus.service
+from gi.repository import GLib
+
+UUID = "00001101-0000-1000-8000-00805f9b34fb"
+PROFILE_PATH = "/io/github/ncr/omaphones/xiaomiprobe"
+START = time.monotonic()
+
+GAIA_VENDOR, DEVICE_VENDOR = 0x000A, 0x001D
+HANDSHAKE, GET_MODE, SET_MODE = 0x0300, 0x1003, 0x1004
+# 0x04 reboots Xiaomi Buds 5 Pro - never a set: value.
+SET_BYTE = {"off": 0x00, "anc": 0x01, "ambient": 0x02}
+
+
+def stamp():
+    return "%7.2fs" % (time.monotonic() - START)
+
+
+def frame(version, vendor, command, payload=b""):
+    return bytes([0xFF, version & 0xFF, 0x00, len(payload)]) + struct.pack(
+        ">HH", vendor, command) + payload
+
+
+def decode(raw):
+    out = []
+    i = 0
+    while i + 8 <= len(raw) and raw[i] == 0xFF:
+        plen = raw[i + 3]
+        vendor, command = struct.unpack(">HH", raw[i + 4:i + 8])
+        payload = raw[i + 8:i + 8 + plen]
+        if len(payload) < plen:
+            break
+        out.append("ver=%d vendor=%04x cmd=%04x payload=%s" % (
+            raw[i + 1], vendor, command, payload.hex() or "-"))
+        i += 8 + plen
+    return out or [raw.hex()]
+
+
+class Link:
+    def __init__(self, fd, plan):
+        self.fd = fd
+        GLib.io_add_watch(fd, GLib.PRIORITY_DEFAULT,
+                          GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR, self.on_io)
+        delay = 400
+        for name, data in plan:
+            GLib.timeout_add(delay, lambda n=name, d=data: (self.send(n, d), False)[1])
+            delay += 700
+
+    def on_io(self, fd, condition):
+        if condition & (GLib.IO_HUP | GLib.IO_ERR):
+            print("%s !! closed" % stamp(), flush=True)
+            self.fd = -1
+            return False
+        data = os.read(fd, 4096)
+        if not data:
+            print("%s !! EOF" % stamp(), flush=True)
+            self.fd = -1
+            return False
+        print("%s <<< %s" % (stamp(), data.hex()), flush=True)
+        for line in decode(data):
+            print("%s     %s" % (stamp(), line), flush=True)
+        return True
+
+    def send(self, name, data):
+        if self.fd < 0:
+            return
+        print("%s >>> %s %s" % (stamp(), name, data.hex()), flush=True)
+        try:
+            os.write(self.fd, data)
+        except OSError as error:
+            print("%s !! write: %s" % (stamp(), error), flush=True)
+
+
+def main():
+    argv = sys.argv[1:]
+    if not argv or argv[0] in ("-h", "--help"):
+        print("usage: xiaomi_probe.py <address> [seconds] [set:off|anc|ambient]")
+        return 0
+    address = argv[0]
+    seconds = 12
+    wanted = None
+    for arg in argv[1:]:
+        if arg.startswith("set:"):
+            wanted = arg.split(":", 1)[1].strip().lower()
+            if wanted not in SET_BYTE:
+                sys.exit("unknown mode %r (off, anc, ambient)" % wanted)
+        else:
+            seconds = int(arg)
+
+    plan = [
+        ("hs", frame(3, GAIA_VENDOR, HANDSHAKE)),
+        ("get", frame(3, DEVICE_VENDOR, GET_MODE)),
+    ]
+    if wanted is not None:
+        plan.append(("set-%s" % wanted, frame(3, DEVICE_VENDOR, SET_MODE,
+                                              bytes([SET_BYTE[wanted]]))))
+        plan.append(("get2", frame(3, DEVICE_VENDOR, GET_MODE)))
+
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    bus = dbus.SystemBus()
+    loop = GLib.MainLoop()
+    link = {"l": None}
+
+    class Profile(dbus.service.Object):
+        @dbus.service.method("org.bluez.Profile1", in_signature="", out_signature="")
+        def Release(self):
+            pass
+
+        @dbus.service.method("org.bluez.Profile1", in_signature="oha{sv}",
+                             out_signature="")
+        def NewConnection(self, path, fd, properties):
+            print("%s == connected" % stamp(), flush=True)
+            link["l"] = Link(fd.take(), plan)
+
+        @dbus.service.method("org.bluez.Profile1", in_signature="o", out_signature="")
+        def RequestDisconnection(self, path):
+            print("%s == BlueZ asked to disconnect" % stamp(), flush=True)
+
+    Profile(bus, PROFILE_PATH)
+    manager = dbus.Interface(bus.get_object("org.bluez", "/org/bluez"),
+                             "org.bluez.ProfileManager1")
+    manager.RegisterProfile(PROFILE_PATH, UUID, {
+        "Name": "Xiaomi probe",
+        "Role": "client",
+        "Channel": dbus.UInt16(0),
+        "RequireAuthentication": dbus.Boolean(False),
+        "RequireAuthorization": dbus.Boolean(False),
+        "AutoConnect": dbus.Boolean(False),
+    })
+
+    def device_path():
+        objects = dbus.Interface(bus.get_object("org.bluez", "/"),
+                                 "org.freedesktop.DBus.ObjectManager").GetManagedObjects()
+        want = address.upper()
+        for path, ifaces in objects.items():
+            dev = ifaces.get("org.bluez.Device1")
+            if dev and str(dev.get("Address", "")).upper() == want:
+                return path
+        sys.exit("no paired device with address %s" % address)
+
+    dev = device_path()
+
+    def connect(attempt=0):
+        def failed(error):
+            print("%s ConnectProfile: %s" % (stamp(), error.get_dbus_message()), flush=True)
+            if attempt < 10:
+                GLib.timeout_add(1500, lambda: connect(attempt + 1))
+
+        dbus.Interface(bus.get_object("org.bluez", dev), "org.bluez.Device1").ConnectProfile(
+            UUID, reply_handler=lambda: None, error_handler=failed, timeout=30)
+        return False
+
+    GLib.timeout_add(500, connect)
+    GLib.timeout_add_seconds(seconds, lambda: (loop.quit(), False)[1])
+    loop.run()
+    try:
+        manager.UnregisterProfile(PROFILE_PATH)
+    except dbus.DBusException:
+        pass
+    print("%s == done" % stamp(), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/xiaomi-bridge
+++ b/xiaomi-bridge
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""Hold one SPP/RFCOMM link to Xiaomi Buds 5 Pro and mirror the listening mode.
+
+    xiaomi-bridge <classic-address>
+
+Prints one JSON object per line, and reads one command per line:
+
+    stdout   {"modes": true, "mode": "anc", "available": ["off","anc","ambient"]}
+             {"modes": false, "error": "..."}
+    stdin    set off | set anc | set ambient
+
+Exit codes, which the shell-side service reads to decide what to do next:
+
+    0   clean stop: SIGTERM/SIGINT, or the widget closed the pipe
+    1   transient: the profile never connected, the handshake went unanswered,
+        or the channel closed under us. Says nothing about the buds, so the
+        service retries with a growing pause
+    3   linked but silent: handshake worked, the listening-mode GET did not.
+        This device speaks Compact GAIA but not this part of it, so the
+        service parks the address
+    4   setup failure: bad arguments, or python-dbus/PyGObject missing. About
+        this machine, not about the buds
+
+Sibling of sony-bridge: same stdout/stdin/exit-code contract, a different
+channel. Sony serves its own UUID; these buds speak Compact GAIA on standard
+SPP (`00001101-…`). Detection is the CSR GAIA UUID in the SDP record
+(`00001100-d102-…`), which they advertise even though that RFCOMM channel
+itself refuses ConnectProfile.
+
+Protocol, confirmed on Xiaomi Buds 5 Pro (QCC-7228) — see PROTOCOL.md:
+
+    frame    FF <ver> <flags=00> <len> <vendor u16be> <cmd u16be> <payload>
+    init     vendor 0x000A cmd 0x0300, answered 0x8300; this device uses ver 3
+    get      vendor 0x001D cmd 0x1003 empty, answered 0x1103, 5-byte payload
+    set      vendor 0x001D cmd 0x1004, one byte; 5-byte copies of GET are
+             rejected (0x1184 payload 05). 0x1104 empty is the SET ack
+
+SET/GET byte, and the name the panel uses. Off and ANC were confirmed on the
+buds. Ambient is 0x02 (same extra flags as 0x03/0x04, and SET 0x02 did not
+drop the link). 0x04 is Moondrop's transparency byte on this vendor - on
+these buds it reboots them, and must never be sent.
+
+    0x00 off     GET 00 01 00 00 00
+    0x01 anc     GET 01 01 01 00 00
+    0x02 ambient GET 02 01 00 01 00
+
+0x03 is accepted and not offered. 0x04 is forbidden.
+"""
+import ctypes
+import json
+import os
+import re
+import signal
+import struct
+import sys
+
+try:
+    import dbus
+    import dbus.mainloop.glib
+    import dbus.service
+    from gi.repository import GLib
+except ImportError as error:
+    sys.stdout.write(json.dumps({
+        "modes": False,
+        "error": "missing python dependency %s - install it with: "
+                 "sudo pacman -S --needed python-dbus python-gobject"
+                 % (getattr(error, "name", None) or error),
+    }) + "\n")
+    sys.stdout.flush()
+    sys.exit(4)
+
+try:
+    from gi.repository import GLibUnix
+    unix_signal_add = GLibUnix.signal_add
+except ImportError:
+    unix_signal_add = GLib.unix_signal_add
+
+# Standard SPP. The CSR GAIA UUID is how the widget picks this backend; this
+# is the channel that actually answers.
+UUID = "00001101-0000-1000-8000-00805f9b34fb"
+PROFILE_PATH = "/io/github/ncr/omaphones/xiaomi"
+
+GAIA_VENDOR = 0x000A
+DEVICE_VENDOR = 0x001D
+HANDSHAKE, HANDSHAKE_RET = 0x0300, 0x8300
+GET_MODE, RET_MODE, SET_MODE, ACK_MODE = 0x1003, 0x1103, 0x1004, 0x1104
+
+# Names the panel already draws. Bytes the buds accepted that have no name yet
+# are not in this table: a GET of one of those leaves `mode` blank so no
+# button pretends to be selected.
+MODE_FROM_BYTE = {0x00: "off", 0x01: "anc", 0x02: "ambient"}
+BYTE_FROM_MODE = {name: byte for byte, name in MODE_FROM_BYTE.items()}
+AVAILABLE = ["off", "anc", "ambient"]
+
+# SET 0x04 reboots Xiaomi Buds 5 Pro. Refused even if a table above drifts.
+FORBIDDEN_SET = frozenset({0x04})
+
+ADDRESS = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+
+USAGE = "usage: xiaomi-bridge <classic-address>"
+
+EXIT_TRANSIENT = 1
+EXIT_UNSUPPORTED = 3
+EXIT_SETUP = 4
+
+REPLY_TIMEOUT = 5
+CONNECT_TIMEOUT = 30
+CONNECT_DELAY = 500
+CONNECT_RETRY = 1500
+CONNECT_ATTEMPTS = 10
+INIT_TIMEOUT = 2000
+INIT_ATTEMPTS = 3
+GET_TIMEOUT = 3000
+# Touch-control changes do not notify on this channel (nothing unsolicited
+# arrived while probing). A light GET is how the panel follows a press on the
+# bud. Two and a half seconds is slower than a person tapping and cheap on
+# RFCOMM.
+POLL_INTERVAL = 2500
+
+
+def emit(payload):
+    try:
+        sys.stdout.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        sys.stdout.flush()
+    except (BrokenPipeError, ValueError):
+        os._exit(0)
+
+
+def arm_parent_death_signal():
+    """Die with the shell that started us.
+
+    Same reason as sony-bridge: an orphaned holder keeps the SPP registration
+    and every later start is handed nothing.
+    """
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        libc.prctl(1, signal.SIGTERM)
+    except Exception:
+        return
+    if os.getppid() == 1:
+        os._exit(0)
+
+
+def frame(version, vendor, command, payload=b""):
+    return bytes([0xFF, version & 0xFF, 0x00, len(payload)]) + struct.pack(
+        ">HH", vendor, command) + payload
+
+
+def take_frames(buffer):
+    """Whole Compact GAIA frames from a byte buffer, leftover bytes kept."""
+    data = bytes(buffer)
+    frames = []
+    index = 0
+    while index < len(data):
+        if data[index] != 0xFF:
+            index += 1
+            continue
+        if index + 8 > len(data):
+            break
+        flags = data[index + 2]
+        # This device answered flags=0, compact length. Anything else is not
+        # a frame we can trust, so skip the 0xFF rather than guess.
+        if flags != 0:
+            index += 1
+            continue
+        length = data[index + 3]
+        need = 8 + length
+        if index + need > len(data):
+            break
+        version = data[index + 1]
+        vendor, command = struct.unpack(">HH", data[index + 4:index + 8])
+        payload = data[index + 8:index + need]
+        frames.append((version, vendor, command, payload))
+        index += need
+    return frames, bytearray(data[index:])
+
+
+def find_device_path(bus, address):
+    wanted = address.upper()
+    objects = dbus.Interface(bus.get_object("org.bluez", "/"),
+                             "org.freedesktop.DBus.ObjectManager").GetManagedObjects()
+    for path, interfaces in objects.items():
+        device = interfaces.get("org.bluez.Device1")
+        if device and str(device.get("Address", "")).upper() == wanted:
+            return str(path)
+    return None
+
+
+class Bridge:
+    def __init__(self, bus, address, loop):
+        self.bus = bus
+        self.address = address
+        self.loop = loop
+        self.exit_code = None
+        self.device = None
+        self.manager = None
+        self.registered = False
+
+        self.fd = None
+        self.watch = None
+        self.buffer = bytearray()
+
+        self.version = 3
+        self.handshake_seen = False
+        self.mode_seen = False
+        self.mode = ""
+        self.last_line = None
+        self.poll = None
+
+        self.pending = ""
+
+    def finish(self, code, message=None):
+        if self.exit_code is not None:
+            return False
+        self.exit_code = code
+        if message:
+            emit({"modes": False, "error": message})
+        self.loop.quit()
+        return False
+
+    def unregister(self):
+        if self.poll is not None:
+            try:
+                GLib.source_remove(self.poll)
+            except Exception:
+                pass
+            self.poll = None
+        if self.watch is not None:
+            try:
+                GLib.source_remove(self.watch)
+            except Exception:
+                pass
+            self.watch = None
+        if self.fd is not None:
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+            self.fd = None
+        if self.manager is not None and self.registered:
+            try:
+                self.manager.UnregisterProfile(PROFILE_PATH, timeout=REPLY_TIMEOUT)
+            except dbus.DBusException:
+                pass
+            self.registered = False
+
+    def register(self):
+        try:
+            device_path = find_device_path(self.bus, self.address)
+        except dbus.DBusException as error:
+            return self.finish(EXIT_TRANSIENT,
+                               "cannot reach BlueZ: %s" % error.get_dbus_message())
+        if not device_path:
+            return self.finish(EXIT_TRANSIENT,
+                               "no paired device with address %s" % self.address)
+        self.device = dbus.Interface(
+            self.bus.get_object("org.bluez", device_path), "org.bluez.Device1")
+        self.manager = dbus.Interface(
+            self.bus.get_object("org.bluez", "/org/bluez"), "org.bluez.ProfileManager1")
+        try:
+            self.manager.RegisterProfile(PROFILE_PATH, UUID, {
+                "Name": "Omaphones Xiaomi",
+                "Role": "client",
+                "Channel": dbus.UInt16(0),
+                "RequireAuthentication": dbus.Boolean(False),
+                "RequireAuthorization": dbus.Boolean(False),
+                "AutoConnect": dbus.Boolean(False),
+            }, timeout=REPLY_TIMEOUT)
+        except dbus.DBusException as error:
+            return self.finish(EXIT_TRANSIENT,
+                               "cannot register the Xiaomi profile: %s"
+                               % error.get_dbus_message())
+        self.registered = True
+        GLib.timeout_add(CONNECT_DELAY, self.connect, 0)
+        return False
+
+    def connect(self, attempt):
+        if self.exit_code is not None or self.fd is not None:
+            return False
+
+        def failed(error):
+            if self.exit_code is not None or self.fd is not None:
+                return
+            if attempt + 1 < CONNECT_ATTEMPTS:
+                GLib.timeout_add(CONNECT_RETRY, self.connect, attempt + 1)
+                return
+            self.finish(EXIT_TRANSIENT, "cannot open the Xiaomi channel: %s"
+                        % error.get_dbus_message())
+
+        try:
+            self.device.ConnectProfile(UUID, reply_handler=lambda: None,
+                                       error_handler=failed, timeout=CONNECT_TIMEOUT)
+        except dbus.DBusException as error:
+            failed(error)
+        return False
+
+    def opened(self, fd):
+        if self.fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            return
+        self.fd = fd
+        self.watch = GLib.io_add_watch(fd, GLib.PRIORITY_DEFAULT,
+                                       GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR,
+                                       self.on_io)
+        self.send_handshake(1)
+
+    def write(self, payload):
+        if self.fd is None:
+            return
+        try:
+            written = 0
+            while written < len(payload):
+                written += os.write(self.fd, payload[written:])
+        except OSError as error:
+            self.finish(EXIT_TRANSIENT, "the Xiaomi channel closed: %s" % error)
+
+    def send_handshake(self, attempt):
+        if self.exit_code is not None or self.handshake_seen:
+            return False
+        if attempt > INIT_ATTEMPTS:
+            return self.finish(EXIT_TRANSIENT,
+                               "the Xiaomi buds did not answer the handshake")
+        self.write(frame(self.version, GAIA_VENDOR, HANDSHAKE))
+        GLib.timeout_add(INIT_TIMEOUT, self.send_handshake, attempt + 1)
+        return False
+
+    def ask_mode(self):
+        if self.exit_code is not None or self.fd is None:
+            return False
+        self.write(frame(self.version, DEVICE_VENDOR, GET_MODE))
+        return True
+
+    def on_get_timeout(self):
+        if self.exit_code is not None or self.mode_seen:
+            return False
+        return self.finish(EXIT_UNSUPPORTED,
+                           "the buds did not answer the listening-mode query")
+
+    def start_poll(self):
+        if self.poll is not None:
+            return
+        self.poll = GLib.timeout_add(POLL_INTERVAL, self.ask_mode)
+
+    def on_io(self, _fd, condition):
+        if condition & (GLib.IO_HUP | GLib.IO_ERR):
+            self.finish(EXIT_TRANSIENT, "the Xiaomi channel closed")
+            return False
+        try:
+            data = os.read(self.fd, 4096)
+        except OSError as error:
+            self.finish(EXIT_TRANSIENT, "the Xiaomi channel closed: %s" % error)
+            return False
+        if not data:
+            self.finish(EXIT_TRANSIENT, "the Xiaomi channel closed")
+            return False
+        self.buffer += data
+        frames, self.buffer = take_frames(self.buffer)
+        for parsed in frames:
+            self.on_frame(*parsed)
+            if self.exit_code is not None:
+                return False
+        return True
+
+    def on_frame(self, version, vendor, command, payload):
+        if 1 <= version <= 4:
+            self.version = version
+        if vendor == GAIA_VENDOR and command == HANDSHAKE_RET:
+            if not self.handshake_seen:
+                self.handshake_seen = True
+                self.ask_mode()
+                GLib.timeout_add(GET_TIMEOUT, self.on_get_timeout)
+            return
+        if vendor != DEVICE_VENDOR:
+            return
+        if command == RET_MODE:
+            self.on_mode(payload)
+            return
+        if command == ACK_MODE:
+            # SET landed; GET is what names it. A GET already in flight from
+            # the poll is enough, and one extra now is cheap.
+            self.ask_mode()
+
+    def on_mode(self, payload):
+        if not payload:
+            return
+        first = not self.mode_seen
+        self.mode_seen = True
+        self.mode = MODE_FROM_BYTE.get(payload[0], "")
+        line = {
+            "modes": True,
+            "mode": self.mode,
+            "available": AVAILABLE,
+        }
+        if first or line != self.last_line:
+            self.last_line = line
+            emit(line)
+        if first:
+            self.start_poll()
+
+    def command(self, line):
+        parts = line.strip().split()
+        if not parts or not self.mode_seen:
+            return
+        if parts[0] == "set" and len(parts) > 1:
+            byte = BYTE_FROM_MODE.get(parts[1])
+            if byte is None or byte in FORBIDDEN_SET:
+                return
+            self.write(frame(self.version, DEVICE_VENDOR, SET_MODE, bytes([byte])))
+
+    def on_stdin(self, _fd, condition):
+        if condition & (GLib.IO_HUP | GLib.IO_ERR):
+            self.finish(0)
+            return False
+        try:
+            chunk = os.read(0, 4096)
+        except OSError:
+            self.finish(0)
+            return False
+        if not chunk:
+            self.finish(0)
+            return False
+        self.pending += chunk.decode("utf-8", "replace")
+        while "\n" in self.pending:
+            line, self.pending = self.pending.split("\n", 1)
+            self.command(line)
+        return True
+
+    def listen_to_stdin(self):
+        GLib.io_add_watch(0, GLib.PRIORITY_DEFAULT,
+                          GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR, self.on_stdin)
+
+
+def main():
+    argv = sys.argv[1:]
+    address = argv[0].strip() if argv else ""
+    if argv and argv[0] in ("-h", "--help"):
+        print(USAGE)
+        return 0
+    if not argv or not ADDRESS.match(address):
+        emit({"modes": False,
+              "error": "%s (not a Bluetooth address: %r)" % (USAGE, address)})
+        sys.exit(EXIT_SETUP)
+
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    try:
+        bus = dbus.SystemBus()
+    except dbus.DBusException as error:
+        emit({"modes": False, "error": "no system bus: %s" % error.get_dbus_message()})
+        sys.exit(EXIT_TRANSIENT)
+
+    loop = GLib.MainLoop()
+    bridge = Bridge(bus, address, loop)
+
+    class Profile(dbus.service.Object):
+        @dbus.service.method("org.bluez.Profile1", in_signature="", out_signature="")
+        def Release(self):
+            bridge.finish(EXIT_TRANSIENT, "BlueZ released the Xiaomi profile")
+
+        @dbus.service.method("org.bluez.Profile1", in_signature="oha{sv}",
+                             out_signature="")
+        def NewConnection(self, path, fd, properties):
+            bridge.opened(fd.take())
+
+        @dbus.service.method("org.bluez.Profile1", in_signature="o", out_signature="")
+        def RequestDisconnection(self, path):
+            bridge.finish(EXIT_TRANSIENT, "the Xiaomi channel closed")
+
+    Profile(bus, PROFILE_PATH)
+    bridge.listen_to_stdin()
+    bridge.register()
+
+    def stop(*_args):
+        bridge.finish(0)
+        return False
+
+    unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, stop)
+    unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, stop)
+
+    try:
+        if bridge.exit_code is None:
+            loop.run()
+    finally:
+        bridge.unregister()
+    sys.exit(bridge.exit_code or 0)
+
+
+if __name__ == "__main__":
+    arm_parent_death_signal()
+    try:
+        main()
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        pass
+    except BaseException as error:
+        emit({"modes": False, "error": "%s: %s" % (type(error).__name__, error)})
+        sys.exit(EXIT_TRANSIENT)


### PR DESCRIPTION
I just added modes switch for my headphones. I could not add separate battery indication support cuz:
The open stacks that do show L/R/case for Xiaomi (Gadgetbridge, MiBudsClient) target Redmi Buds (Xiaomi protobuf over SPP). This set is Qualcomm QCC-7228; those frames close the SPP link and must not be sent.

On the Compact GAIA channel that works for ANC, the battery GET does not return usable percentages (values stay 0 / 0xFF while BlueZ reports ~90%). Dual GATT Battery services appear in the tree, but ATT is not connected while Classic A2DP is up, so those reads fail.

So the widget keeps BlueZ’s single HFP figure until a confirmed LE or vendor path for L/R/case is found.